### PR TITLE
find_many returns empty array when no results are found instead of a …

### DIFF
--- a/src/Granada/Orm/Wrapper.php
+++ b/src/Granada/Orm/Wrapper.php
@@ -169,7 +169,21 @@ class Wrapper extends ORM {
      */
     public function find_many() {
         $instances = parent::find_many();
-        return $instances ? Eager::hydrate($this, $instances, self::$_config[$this->_connection_name]['return_result_sets']) : $instances;
+
+		// Check if now rows returned
+		if (is_array($instances)) {
+			if (!$instances) {
+				return array();
+			}
+		} else {
+			if (!$instances->has_results()) {
+				// No rows, return empty array
+				return array();
+			}
+		}
+
+		// Add eager relationships
+        return Eager::hydrate($this, $instances, self::$_config[$this->_connection_name]['return_result_sets']);
     }
 
     /**

--- a/src/Granada/ResultSet.php
+++ b/src/Granada/ResultSet.php
@@ -41,6 +41,14 @@ class ResultSet implements ArrayAccess, Countable, IteratorAggregate {
     }
 
     /**
+     * Determine if the result set is empty
+     * @return boolean
+     */
+    public function has_results() {
+        return !empty($this->_results);
+    }
+
+    /**
      * Get the current result set as an array
      * @return array
      */

--- a/tests/granada/GranadaNewTest.php
+++ b/tests/granada/GranadaNewTest.php
@@ -202,6 +202,37 @@ class GranadaNewTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(array(), $pairs);
     }
 
+    public function testfindMany(){
+        $cars = Car::find_many();
+		// Not an empty array
+		$this->assertNotSame(array(), $cars);
+
+        $expected = array(
+            '1' => 'Car1',
+            '2' => 'Car2',
+            '3' => 'Car3',
+            '4' => 'Car4'
+        );
+		foreach ($cars as $id => $car) {
+        	$this->assertEquals($id, $car->id);
+        	$this->assertEquals($expected[$id], $car->name);
+		}
+    }
+
+    public function testfindManyFiltered(){
+        $cars = Car::where('id',3)->find_many();
+		// Not an empty array
+		$this->assertNotSame(array(), $cars);
+
+        $expected = array(
+            '3' => 'Car3',
+        );
+		foreach ($cars as $id => $car) {
+        	$this->assertEquals($id, $car->id);
+        	$this->assertEquals($expected[$id], $car->name);
+		}
+    }
+
     public function testNoResultsfindMany(){
         $cars = Car::where('id',10)->find_many();
         $this->assertEquals(0, count($cars));


### PR DESCRIPTION
…ResultSet with no items so that if ($result) works