### PR TITLE
Fix regression

### DIFF
--- a/src/Granada/Orm/Wrapper.php
+++ b/src/Granada/Orm/Wrapper.php
@@ -163,8 +163,7 @@ class Wrapper extends ORM {
     /**
      * Tell the ORM that you are expecting multiple results
      * from your query, and execute it. Will return an array
-     * of instances of the ORM class, or an empty array if
-     * no rows were returned.
+     * or ResultSet of instances of the ORM class
      * @return array|\Granada\ResultSet
      */
     public function find_many() {
@@ -173,12 +172,11 @@ class Wrapper extends ORM {
 		// Check if now rows returned
 		if (is_array($instances)) {
 			if (!$instances) {
-				return array();
+				return $instances;
 			}
 		} else {
 			if (!$instances->has_results()) {
-				// No rows, return empty array
-				return array();
+				return $instances;
 			}
 		}
 

--- a/tests/granada/GranadaNewTest.php
+++ b/tests/granada/GranadaNewTest.php
@@ -235,6 +235,7 @@ class GranadaNewTest extends PHPUnit_Framework_TestCase {
 
     public function testNoResultsfindMany(){
         $cars = Car::where('id',10)->find_many();
+        $this->assertSame(array(), $cars->as_array());
         $this->assertEquals(0, count($cars));
     }
 

--- a/tests/granada/GranadaNewTest.php
+++ b/tests/granada/GranadaNewTest.php
@@ -206,6 +206,7 @@ class GranadaNewTest extends PHPUnit_Framework_TestCase {
         $cars = Car::find_many();
 		// Not an empty array
 		$this->assertNotSame(array(), $cars);
+        $this->assertEquals(true, $cars->has_results());
 
         $expected = array(
             '1' => 'Car1',
@@ -237,6 +238,7 @@ class GranadaNewTest extends PHPUnit_Framework_TestCase {
         $cars = Car::where('id',10)->find_many();
         $this->assertSame(array(), $cars->as_array());
         $this->assertEquals(0, count($cars));
+        $this->assertEquals(false, $cars->has_results());
     }
 
     public function testfilters(){


### PR DESCRIPTION
To do a test if no items returned need to do instead 
`if (!$items->has_results()) {}`