### PR TITLE
Fix dirty detection code

### DIFF
--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -2054,7 +2054,7 @@ class ORM implements ArrayAccess {
             }
             $oldval = array_key_exists($field, $this->_data) ? $this->_data[$field] : null;
             $this->_data[$field] = $value;
-            if ($this->is_new() || $expr || $oldval != $value) {
+            if ($this->is_new() || $expr || $oldval !== $value) {
                 $this->_dirty_fields[$field] = $value;
             }
             if (false === $expr and isset($this->_expr_fields[$field])) {
@@ -2073,7 +2073,7 @@ class ORM implements ArrayAccess {
      * @return bool
      */
     public function is_dirty($key) {
-        return isset($this->_dirty_fields[$key]);
+        return array_key_exists($key, $this->_dirty_fields);
     }
 
     /**

--- a/tests/orm/ORMTest.php
+++ b/tests/orm/ORMTest.php
@@ -59,6 +59,30 @@ class ORMTest extends PHPUnit_Framework_TestCase {
 
     }
 
+    public function testIsDirtySimilarValue() {
+        $model = ORM::for_table('test')->create();
+        $model->test = 0;
+        $this->assertTrue($model->is_dirty('test'));
+        $model->save();
+        $this->assertFalse($model->is_dirty('test'));
+        $model->test = 0;
+        $this->assertFalse($model->is_dirty('test'));
+
+        $model->test = '';
+        $this->assertTrue($model->is_dirty('test'));
+        $model->save();
+        $this->assertFalse($model->is_dirty('test'));
+        $model->test = '';
+        $this->assertFalse($model->is_dirty('test'));
+
+        $model->test = null;
+        $this->assertTrue($model->is_dirty('test'));
+        $model->save();
+        $this->assertFalse($model->is_dirty('test'));
+        $model->test = null;
+        $this->assertFalse($model->is_dirty('test'));
+    }
+
     public function testArrayAccess() {
         $value = 'test';
         $model = ORM::for_table('test')->create();


### PR DESCRIPTION
Some fields were not being saved to the database because they were equal but not the same.
For example, 0 and ""
Some fields when setting to null were not being seen as dirty because isset does not see array elements that contain null as existing. 