### PR TITLE
Add get_select_query() function

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -264,6 +264,11 @@ Similarly for having:
 		->find_one();
         // SELECT * FROM `user` GROUP BY `name` HAVING `name` = 'Joe' LIMIT 1
 
+## Get raw SELECT query
+
+Sometimes you may want to build a raw SELECT query for use, e.g. to send to a reporting module that directly connects to the database.
+Instead of calling `find_many()` call `get_select_query()` and it will give you the raw SELECT ready to send to the database server.
+
 # Default filtering
 
 In some cases a default filter is very useful.

--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -661,6 +661,16 @@ class ORM implements ArrayAccess {
     }
 
     /**
+     * Instead of running the query, get the query that would be run for a find_many() call
+     * @param string $connection_name
+     * @return string
+     */
+    public function get_select_query($connection_name = self::DEFAULT_CONNECTION) {
+        $this->_log_query($this->_build_select(), $this->_values, $connection_name);
+        return $this->get_last_query();
+    }
+
+    /**
      * Tell the ORM that you are expecting multiple results
      * from your query, and execute it. Will return an array
      * of instances of the ORM class, or an empty array if

--- a/tests/orm/QueryBuilderMssqlTest.php
+++ b/tests/orm/QueryBuilderMssqlTest.php
@@ -33,6 +33,7 @@ class QueryBuilderMssqlTest extends PHPUnit_Framework_TestCase {
     public function testLimit() {
         ORM::for_table('widget')->limit(5)->find_many();
         $expected = 'SELECT TOP 5 * FROM "widget"';
+        $this->assertSame($expected, ORM::for_table('widget')->limit(5)->get_select_query());
         $this->assertEquals($expected, ORM::get_last_query());
     }
 

--- a/tests/orm/QueryBuilderTest.php
+++ b/tests/orm/QueryBuilderTest.php
@@ -879,4 +879,30 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
         $expected = "UPDATE `widget` SET `added` = NOW() WHERE `id` = '1'";
         $this->assertEquals($expected, ORM::get_last_query());
     }
+
+    public function testGetSelectQuery() {
+        $this->assertSame("SELECT * FROM `widget`", ORM::for_table('widget')->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE `name` != 'Fred'", ORM::for_table('widget')->where_not_equal('name', 'Fred')->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE `name` IN ('Fred', 'Joe')", ORM::for_table('widget')->where_in('name', array('Fred', 'Joe'))->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE 0", ORM::for_table('widget')->where_in('name', array())->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE `name` NOT IN ('Fred', 'Joe')", ORM::for_table('widget')->where_not_in('name', array('Fred', 'Joe'))->get_select_query());
+        $this->assertSame("SELECT * FROM `widget`", ORM::for_table('widget')->where_not_in('name', array())->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE ( `age` < '20' OR `age` IS NULL )", ORM::for_table('widget')->where_lt_or_null('age', '20')->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE ( `age` <= '20' OR `age` IS NULL )", ORM::for_table('widget')->where_lte_or_null('age', '20')->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE ( `age` > '20' OR `age` IS NULL )", ORM::for_table('widget')->where_gt_or_null('age', '20')->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE ( `age` >= '20' OR `age` IS NULL )", ORM::for_table('widget')->where_gte_or_null('age', '20')->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE (( `name` = 'Joe' ) OR ( `name` = 'Fred' ))", ORM::for_table('widget')->where_any_is(array(
+            array('name' => 'Joe'),
+            array('name' => 'Fred')))->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE (( `name` = 'Joe' AND `age` = '10' ) OR ( `name` = 'Fred' AND `age` = '20' ))", ORM::for_table('widget')->where_any_is(array(
+            array('name' => 'Joe', 'age' => 10),
+            array('name' => 'Fred', 'age' => 20)))->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE (( `name` = 'Joe' ) OR ( `name` = 'Fred' AND `age` = '20' ))", ORM::for_table('widget')->where_any_is(array(
+            array('name' => 'Joe'),
+            array('name' => 'Fred', 'age' => 20)))->get_select_query());
+        $this->assertSame("SELECT * FROM `widget` WHERE (( `name` = 'Joe' AND `age` > '10' ) OR ( `name` = 'Fred' AND `age` > '20' ))", ORM::for_table('widget')->where_any_is(array(
+            array('name' => 'Joe', 'age' => 10),
+            array('name' => 'Fred', 'age' => 20)), array('age' => '>'))->get_select_query());
+        $this->assertSame('SELECT * FROM `widget` WHERE username LIKE "ben%"', ORM::for_table('widget')->where_raw('username LIKE "ben%"')->get_select_query());
+    }
 }


### PR DESCRIPTION
Returns the SELECT statement that would have been sent to the database if find_many() was called