### PR TITLE
Suppress PHP8.1 error message for ORM

### DIFF
--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -2335,19 +2335,22 @@ class ORM implements ArrayAccess {
     // --------------------- //
     // --- MAGIC METHODS --- //
     // --------------------- //
+    #[\ReturnTypeWillChange]
     public function __get($key) {
         return $this->offsetGet($key);
     }
 
+    #[\ReturnTypeWillChange]
     public function __set($key, $value) {
         $this->offsetSet($key, $value);
     }
 
+    #[\ReturnTypeWillChange]
     public function __unset($key) {
         $this->offsetUnset($key);
     }
 
-
+    #[\ReturnTypeWillChange]
     public function __isset($key) {
         return $this->offsetExists($key);
     }


### PR DESCRIPTION
Example error:

> Deprecated: Return type of Granada\ORM::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in granadaorm/granada/src/Granada/ORM.php on line 2315

Better would be to set the return type. Not sure if that will break something for others.