### PR TITLE
Suppress PHP8.1 error message for ORM

### DIFF
--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -2311,15 +2311,17 @@ class ORM implements ArrayAccess {
     // --------------------- //
     // ---  ArrayAccess  --- //
     // --------------------- //
-
+    #[\ReturnTypeWillChange]
     public function offsetExists($key) {
         return isset($this->_data[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($key) {
         return $this->get($key);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value) {
         if(is_null($key)) {
             throw new \InvalidArgumentException('You must specify a key/array index.');
@@ -2327,6 +2329,7 @@ class ORM implements ArrayAccess {
         $this->set($key, $value);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key) {
         unset($this->_data[$key]);
         unset($this->_dirty_fields[$key]);


### PR DESCRIPTION
Example error:

> Deprecated: Return type of Granada\ORM::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in granadaorm/granada/src/Granada/ORM.php on line 2315