### PR TITLE
PHP 8.1: Skip null parameters for PDO::quote()

### DIFF
--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -463,8 +463,11 @@ class ORM implements ArrayAccess {
         }
 
         if (count($parameters) > 0) {
-            // Escape the parameters
-            $parameters = array_map(array(self::$_db[$connection_name], 'quote'), $parameters);
+            // Escape the parameters it not null
+            foreach ($parameters as $key => $parameter)
+            {
+                $parameters[$key] = ($parameter === null) ? 'NULL' : self::$_db[$connection_name]->quote($parameter);
+            }
 
             // Avoid %format collision for vsprintf
             $query = str_replace("%", "%%", $query);

--- a/tests/orm/QueryBuilderTest.php
+++ b/tests/orm/QueryBuilderTest.php
@@ -729,6 +729,15 @@ class QueryBuilderTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, ORM::get_last_query());
     }
 
+    public function testInsertDataWithNull() {
+        $widget = ORM::for_table('widget')->create();
+        $widget->name = "Fred";
+        $widget->age = null;
+        $widget->save();
+        $expected = "INSERT INTO `widget` (`name`, `age`) VALUES ('Fred', NULL)";
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
     public function testUpdateSameData() {
         $widget = ORM::for_table('widget')->find_one(1);
         $widget->name = "Fred"; // Does not change so does not write in the database


### PR DESCRIPTION
Fixes #37