### PR TITLE
change no row found for find_one() from false to null

### DIFF
--- a/src/Granada/ORM.php
+++ b/src/Granada/ORM.php
@@ -643,7 +643,7 @@ class ORM implements ArrayAccess {
         $rows = $this->limit(1)->_run();
 
         if (empty($rows)) {
-            return false;
+            return null;
         }
 
         return $this->_create_instance_from_row($rows[0]);

--- a/src/Granada/Orm/Wrapper.php
+++ b/src/Granada/Orm/Wrapper.php
@@ -70,8 +70,8 @@ class Wrapper extends ORM {
      * it with the supplied Idiorm instance.
      */
     protected function _create_model_instance($orm) {
-        if ($orm === false) {
-            return false;
+        if (is_null($orm)) {
+            return null;
         }
         $model = new $this->_class_name();
         $orm->resultSetClass = $model->get_resultSetClass();

--- a/tests/granada/EagerTest.php
+++ b/tests/granada/EagerTest.php
@@ -45,7 +45,7 @@ class EagerTest extends PHPUnit_Framework_TestCase {
 
         $expectedSql   = array();
         $expectedSql[] = "SELECT * FROM `car` WHERE `car`.`is_deleted` = '0' AND `id` = '1' LIMIT 1";
-        $expectedSql[] = "SELECT * FROM `manufactor` WHERE `id` IN ('1')";
+        $expectedSql[] = "SELECT * FROM `manufactor` WHERE `enabled` = '1' AND `id` IN ('1')";
 
         $fullQueryLog = ORM::get_query_log();
 
@@ -62,7 +62,7 @@ class EagerTest extends PHPUnit_Framework_TestCase {
         $expectedSql = array();
         $expectedSql[] = "SELECT * FROM `car` WHERE `car`.`is_deleted` = '0' AND `id` = '1' LIMIT 1";
         $expectedSql[] = "SELECT * FROM `owner` WHERE `id` IN ('1')";
-        $expectedSql[] = "SELECT * FROM `manufactor` WHERE `id` IN ('1')";
+        $expectedSql[] = "SELECT * FROM `manufactor` WHERE `enabled` = '1' AND `id` IN ('1')";
 
         $fullQueryLog = ORM::get_query_log();
 
@@ -134,7 +134,7 @@ class EagerTest extends PHPUnit_Framework_TestCase {
         $expectedSql = array();
         $expectedSql[] = "SELECT * FROM `car` WHERE `car`.`is_deleted` = '0'";
         $expectedSql[] = "SELECT * FROM `owner` WHERE `id` IN ('1', '2', '3', '4')";
-        $expectedSql[] = "SELECT * FROM `manufactor` WHERE `id` IN ('1', '2')";
+        $expectedSql[] = "SELECT * FROM `manufactor` WHERE `enabled` = '1' AND `id` IN ('1', '2')";
 
         $fullQueryLog = ORM::get_query_log();
 
@@ -251,7 +251,7 @@ class EagerTest extends PHPUnit_Framework_TestCase {
         $expectedSql    = array();
         $expectedSql[]  = "SELECT * FROM `owner` WHERE `id` = '1' LIMIT 1";
         $expectedSql[]  = "SELECT * FROM `car` WHERE `car`.`is_deleted` = '0' AND `owner_id` IN ('1')";
-        $expectedSql[]  = "SELECT * FROM `manufactor` WHERE `id` IN ('1')";
+        $expectedSql[]  = "SELECT * FROM `manufactor` WHERE `enabled` = '1' AND `id` IN ('1')";
 
         $this->assertEquals($expectedSql, $actualSql);
     }
@@ -272,5 +272,25 @@ class EagerTest extends PHPUnit_Framework_TestCase {
     public function testLazyLoading() {
         $owner = Model::factory('Owner')->find_one(1);
         $this->assertEquals($owner->car->manufactor_id, 1);
+    }
+
+    public function testLazyMissingManufacturerNull() {
+        $man1 = Manufactor::find_one(1);
+        $man1->enabled = false;
+        $man1->save();
+
+        $car1 = Car::find_one(1);
+
+        $this->assertNull($car1->manufactor);
+    }
+
+    public function testEagerMissingManufacturerNull() {
+        $man1 = Manufactor::find_one(1);
+        $man1->enabled = false;
+        $man1->save();
+
+        $car1 = Car::with('manufactor')->find_one(1);
+
+        $this->assertNull($car1->manufactor);
     }
 }

--- a/tests/granada/GranadaNewTest.php
+++ b/tests/granada/GranadaNewTest.php
@@ -601,4 +601,9 @@ class GranadaNewTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, $car->clean_values());
     }
 
+    public function testNotFound() {
+        $car = Model::factory('Car')->find_one(20);
+        $this->assertNull($car);
+    }
+
 }

--- a/tests/models.php
+++ b/tests/models.php
@@ -28,7 +28,7 @@ class Part extends Model {
 
 class Car extends Model {
     public function manufactor() {
-        return $this->belongs_to('Manufactor');
+        return $this->belongs_to('Manufactor')->where('enabled', 1);
     }
 
     public function owner() {

--- a/tests/models.sql
+++ b/tests/models.sql
@@ -1,5 +1,6 @@
 CREATE TABLE manufactor (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    enabled INTEGER,
     name TEXT
 );
 
@@ -33,8 +34,8 @@ CREATE TABLE car_part (
     FOREIGN KEY (part_id) REFERENCES part (id)
 );
 
-INSERT INTO manufactor(id,name) VALUES (1, 'Manufactor1');
-INSERT INTO manufactor(id,name) VALUES (2, 'Manufactor2');
+INSERT INTO manufactor(id,name,enabled) VALUES (1, 'Manufactor1', 1);
+INSERT INTO manufactor(id,name,enabled) VALUES (2, 'Manufactor2', 1);
 
 INSERT INTO owner(id,name) VALUES (1, 'Owner1');
 INSERT INTO owner(id,name) VALUES (2, 'Owner2');


### PR DESCRIPTION
Eager references to a missing related item (e.g. by not being enabled or deleted) return null however lazy references return false.

This is because find_one() returns false if not found.

Change the behaviour of find_one() to return null if not found.

As potentially backwards-breaking, a new major version needs to be made.

Fixes #39